### PR TITLE
Set _images to instance variable

### DIFF
--- a/openpyxl_image_loader/sheet_image_loader.py
+++ b/openpyxl_image_loader/sheet_image_loader.py
@@ -10,10 +10,12 @@ from PIL import Image
 
 class SheetImageLoader:
     """Loads all images in a sheet"""
-    _images = {}
 
     def __init__(self, sheet):
         """Loads all sheet images"""
+        
+        self._images = {}
+        
         sheet_images = sheet._images
         for image in sheet_images:
             row = image.anchor._from.row + 1


### PR DESCRIPTION
I noticed that every instance of the SheetImageLoader accessed the same _images variable. This caused problems where a new instance of the class thought that there was an image in a cell where there wasn't. I changed _images to an instance variable which is specific to the instance instead of the class.