### PR TITLE
Normalise requirements in readme and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Openpyxl wrapper that gets images from cells
 ## Requirements
 
 - [openpyxl](https://pypi.org/project/openpyxl/)
+- [Pillow](https://pypi.org/project/Pillow/)
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
     ],
     packages=['openpyxl_image_loader'],
     include_package_data=True,
-    install_requires=['Pillow', ],
+    install_requires=['Pillow', 'openpyxl'],
 )


### PR DESCRIPTION
Stating Pillow requirement in README for clarity; added openpyxl as a requirement to setup.py